### PR TITLE
Add new funding.schema.json to use a json-schema.org schema definition.

### DIFF
--- a/content/funding-manifest.md
+++ b/content/funding-manifest.md
@@ -7,12 +7,12 @@ slug = "funding-manifest"
 
 `funding.json` is an open manifest (JSON schema) that acts as a signaling and discovery mechanism for projects seeking funding. It is a self-contained manifest file that FOSS (Free and Open Source Software) projects, developers, and communities can host on their websites or repositories to describe their financial requirements in a structured, machine-readable manner. It acts like a robots.txt file or a progressive web app manifest, allowing it to be publicly crawled and indexed, to make projects in need of financial assistance discoverable.
 
-See this [example listing](https://dir.floss.fund/view/@example.com) for a demonstration of how a manifest could be parsed and presented.
+See the [directory](https://dir.floss.fund) for a demonstration of how manifest files can be parsed and presented.
 
 
 ## Schema
 
-Current version is v1.0.0
+The current version is v1.0.0. A human readable version with comments is shown below. The JSON schema (json-schema.org) is [available here](/schema/v1.0.0/funding.schema.json).
 
 ```json
 {{ read_file(path="static/static/funding.schema.json") }}

--- a/static/schema/v1.0.0/funding.schema.json
+++ b/static/schema/v1.0.0/funding.schema.json
@@ -1,0 +1,286 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["version", "entity", "funding"],
+    "properties": {
+        "version": {
+            "type": "string",
+            "description": "Schema version"
+        },
+        "entity": {
+            "type": "object",
+            "description": "The entity associated with the project, soliciting funds.",
+            "required": ["type", "role", "name", "email", "description", "webpageUrl"],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Type of the entity. [individual, group, organisation, other], Use the closest approximation.",
+                    "enum": ["individual", "group", "organisation", "other"]
+                },
+                "role": {
+                    "type": "string",
+                    "description": "Role in relation to the project. [owner, steward, maintainer, contributor, other]. Use the closest approximation.",
+                    "enum": ["owner", "steward", "maintainer", "contributor", "other"]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the entity.",
+                    "maxLength": 250
+                },
+                "email": {
+                    "type": "string",
+                    "description": "Contact email.",
+                    "maxLength": 250
+                },
+                "phone": {
+                    "type": "string",
+                    "description": "Contact phone number. Generally suitable for organisations.",
+                    "maxLength": 32
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Information about the entity.",
+                    "maxLength": 2000
+                },
+                "webpageUrl": {
+                    "type": "object",
+                    "required": ["url"],
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Webpage with information about the entity.",
+                            "anyOf": [
+                                { "pattern": "^(https?://)" },
+                                { "pattern": "^$" }
+                            ],
+                            "maxLength": 250
+                        },
+                        "wellKnown": {
+                            "type": "string",
+                            "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
+                            "anyOf": [
+                                { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
+                                { "pattern": "^$" }
+                            ],
+                            "maxLength": 250
+                        }
+                    }
+                }
+            }
+        },
+        "projects": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "description": "One or more projects for which the funding is solicited.",
+                "required": ["guid", "name", "description", "webpageUrl", "repositoryUrl", "licenses", "tags"],
+                "properties": {
+                    "guid": {
+                        "type": "string",
+                        "description": "A short unique ID for the project. Lowercase-alphanumeric-dashes only. eg: my-cool-project.",
+                        "anyOf": [
+                            { "pattern": "^[a-z0-9-]+$" },
+                            { "pattern": "^$" }
+                        ],
+                        "maxLength": 32
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the project.",
+                        "maxLength": 250
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the project.",
+                        "maxLength": 2000
+                    },
+                    "webpageUrl": {
+                        "type": "object",
+                        "required": ["url"],
+                        "properties": {
+                            "url": {
+                                "type": "string",
+                                "description": "Webpage with information about the project.",
+                                "pattern": "^(https?://)",
+                                "maxLength": 250
+                            },
+                            "wellKnown": {
+                                "type": "string",
+                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
+                                "anyOf": [
+                                    { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
+                                    { "pattern": "^$" }
+                                ],
+                                "maxLength": 250
+                            }
+                        }
+                    },
+                    "repositoryUrl": {
+                        "type": "object",
+                        "required": ["url"],
+                        "properties": {
+                            "url": {
+                                "type": "string",
+                                "description": "URL of the repository where the project's source code and other assets are available.",
+                                "pattern": "^(https?://)",
+                                "maxLength": 250
+                            },
+                            "wellKnown": {
+                                "type": "string",
+                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should be a file in the repository to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
+                                "anyOf": [
+                                    { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
+                                    { "pattern": "^$" }
+                                ],
+                                "maxLength": 250
+                            }
+                        }
+                    },
+                    "licenses": {
+                        "type": "array",
+                        "description": "The project's licenses (up to 5). For standard licenses, use the license ID from the SDPX index prefixed by \"spdx:\". eg: \"spdx:GPL-3.0\", \"spdx:CC-BY-SA-4.0\".",
+                        "maxItems": 5,
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "description": "Up to 10 general tags describing the project. For reference, see https://floss.fund/static/project-tags.txt.",
+                        "maxItems": 10,
+                        "items": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]+$",
+                            "maxLength": 32
+                        }
+                    }
+                }
+            }
+        },
+        "funding": {
+            "type": "object",
+            "description": "This describes one or more channels via which the entity can receive funds.",
+            "required": ["channels", "plans"],
+            "properties": {
+                "channels": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["guid", "type"],
+                        "properties": {
+                            "guid": {
+                                "type": "string",
+                                "description": "A short unique ID for the channel. Lowercase-alphanumeric-dashes only. eg: mybank, my-paypal.",
+                                "pattern": "^[a-z0-9-]+$",
+                                "maxLength": 32
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "Type of the channel. [bank, payment-provider, cheque, cash, other].",
+                                "enum": ["bank", "payment-provider", "cheque", "cash", "other"]
+                            },
+                            "address": {
+                                "type": "string",
+                                "description": "A short unstructured textual representation of the payment address for the channel. eg: \"Account: 12345 (branch: ABCX)\", \"mypaypal@domain.com\", \"https://payment-url.com\", or a physical address for cheques.",
+                                "maxLength": 250
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Any additional description or instructions for the payment channel.",
+                                "maxLength": 500
+                            }
+                        }
+                    }
+                },
+                "plans": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["guid", "status", "name", "amount", "currency", "frequency", "channels"],
+                        "properties": {
+                            "guid": {
+                                "type": "string",
+                                "description": "A short unique ID for the plan. Lowercase-alphanumeric-dashes only. eg: mybank, paypal.",
+                                "pattern": "^[a-z0-9-]+$",
+                                "maxLength": 32
+                            },
+                            "status": {
+                                "type": "string",
+                                "description": "Indicates whether this plan is currently active or inactive. [active, inactive].",
+                                "enum": ["active", "inactive"]
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the funding plan. eg: \"Starter support plan\", \"Infra hosting\", \"Monthly funding plan\".",
+                                "maxLength": 250
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Any additional description or instructions for the funding plan."
+                            },
+                            "amount": {
+                                "type": "number",
+                                "description": "The solicited amount for this plan. 0 is a wildcard that indicates \"any amount\"."
+                            },
+                            "currency": {
+                                "type": "string",
+                                "description": "Three letter ISO 4217 currency code. eg: USD, EUR.",
+                                "pattern": "^[A-Z]{3}$"
+                            },
+                            "frequency": {
+                                "type": "string",
+                                "description": "Frequency of the funding. [one-time, weekly, fortnightly, monthly, yearly, other]",
+                                "enum": ["one-time", "weekly", "fortnightly", "monthly", "yearly", "other"]
+                            },
+                            "channels": {
+                                "type": "array",
+                                "description": "One or more channel IDs defined in channels[] via which this plan can accept payments",
+                                "items": {
+                                    "type": "string",
+                                    "pattern": "^[a-z0-9-]+$",
+                                    "maxLength": 32
+                                }
+                            }
+                        }
+                    }
+                },
+                "history": {
+                    "type": "array",
+                    "description": "A simple summary of funding history. Only include if at least one, either income or expenses, have to be communicated.",
+                    "items": {
+                        "type": "object",
+                        "required": ["year", "currency"],
+                        "properties": {
+                            "year": {
+                                "type": "integer",
+                                "description": "Year (fiscal, preferably)."
+                            },
+                            "income": {
+                                "type": "number",
+                                "description": "Income for the year."
+                            },
+                            "expenses": {
+                                "type": "number",
+                                "description": "Expenses for the year."
+                            },
+                            "taxes": {
+                                "type": "number",
+                                "description": "Taxes for the year."
+                            },
+                            "currency": {
+                                "type": "string",
+                                "description": "Three letter ISO 4217 currency code. eg: USD, EUR.",
+                                "pattern": "^[A-Z]{3}$"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Any additional description.",
+                                "maxLength": 500
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/static/schema/v1.0.0/funding.schema.json
+++ b/static/schema/v1.0.0/funding.schema.json
@@ -19,7 +19,7 @@
                 },
                 "role": {
                     "type": "string",
-                    "description": "Role in relation to the project. [owner, steward, maintainer, contributor, other]. Use the closest approximation.",
+                    "description": "Role in relation to the entity. [owner, steward, maintainer, contributor, other]. Use the closest approximation.",
                     "enum": ["owner", "steward", "maintainer", "contributor", "other"]
                 },
                 "name": {

--- a/static/static/funding.example.json
+++ b/static/static/funding.example.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://floss.fund/static/funding.schema.json#",
     "version": "v1.0.0",
     "entity": {
         "type": "individual",

--- a/static/static/funding.example.json
+++ b/static/static/funding.example.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://floss.fund/static/funding.schema.json#",
+    "$schema": "https://floss.fund/schema/v1.0.0/funding.schema.json#",
     "version": "v1.0.0",
     "entity": {
         "type": "individual",

--- a/static/static/funding.schema.json
+++ b/static/static/funding.schema.json
@@ -1,68 +1,280 @@
 {
-    "version": "v1.0.0",
-
-    // Required. The entity associated with the project, soliciting funds.
-    // This can be an individual, organisation, community etc.
-    "entity": {
-        "type": "",                     // Required. [individual, group, organisation, other]. Use the closest approximation.
-        "role": "",                     // Required. [owner, steward, maintainer, contributor, other]. Use the closest approximation.
-        "name": "",                     // Required. Name of the entity. Max len 250.
-        "email": "",                    // Required. Max len 250.
-        "phone": "",                    // Optional. Generally suitable for organisations. Max len 32.
-        "description": "",              // Required. Information about the entity. Max len 2000.
-        "webpageUrl": {
-            "url": "",                  // Required. Webpage with information about the entity. Starts with https:// or http://. Max len 250.
-            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. Starts with https:// or http://. Max len 250.
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["version", "entity", "funding"],
+    "properties": {
+        "version": {
+            "type": "string",
+            "description": "Schema version"
+        },
+        "entity": {
+            "type": "object",
+            "description": "The entity associated with the project, soliciting funds.",
+            "required": ["type", "role", "name", "email", "description", "webpageUrl"],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Type of the entity. Use the closest approximation.",
+                    "enum": ["individual", "group", "organisation", "other"]
+                },
+                "role": {
+                    "type": "string",
+                    "description": "Role in relation to the project. Use the closest approximation.",
+                    "enum": ["owner", "steward", "maintainer", "contributor", "other"]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the entity.",
+                    "maxLength": 250
+                },
+                "email": {
+                    "type": "string",
+                    "description": "Contact email.",
+                    "maxLength": 250
+                },
+                "phone": {
+                    "type": "string",
+                    "description": "Contact phone number. Generally suitable for organisations.",
+                    "maxLength": 32
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Information about the entity.",
+                    "maxLength": 2000
+                },
+                "webpageUrl": {
+                    "type": "object",
+                    "required": ["url"],
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Webpage with information about the entity.",
+                            "anyOf": [
+                                { "pattern": "^(https?://)" },
+                                { "pattern": "^$" }
+                            ],
+                            "maxLength": 250
+                        },
+                        "wellKnown": {
+                            "type": "string",
+                            "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname.",
+                            "anyOf": [
+                                { "pattern": "^(https?://)" },
+                                { "pattern": "^$" }
+                            ],
+                            "maxLength": 250
+                        }
+                    }
+                }
+            }
+        },
+        "projects": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "description": "One or more projects for which the funding is solicited.",
+                "required": ["guid", "name", "description", "webpageUrl", "repositoryUrl", "licenses", "tags"],
+                "properties": {
+                    "guid": {
+                        "type": "string",
+                        "description": "A short unique ID for the project. Lowercase-alphanumeric-dashes only. eg: my-cool-project.",
+                        "anyOf": [
+                            { "pattern": "^[a-z0-9-]+$" },
+                            { "pattern": "^$" }
+                        ],
+                        "maxLength": 32
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the project.",
+                        "maxLength": 250
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the project.",
+                        "maxLength": 2000
+                    },
+                    "webpageUrl": {
+                        "type": "object",
+                        "required": ["url"],
+                        "properties": {
+                            "url": {
+                                "type": "string",
+                                "description": "Webpage with information about the project.",
+                                "pattern": "^(https?://)",
+                                "maxLength": 250
+                            },
+                            "wellKnown": {
+                                "type": "string",
+                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname.",
+                                "pattern": "^(https?://)",
+                                "maxLength": 250
+                            }
+                        }
+                    },
+                    "repositoryUrl": {
+                        "type": "object",
+                        "required": ["url"],
+                        "properties": {
+                            "url": {
+                                "type": "string",
+                                "description": "URL of the repository where the project's source code and other assets are available.",
+                                "pattern": "^(https?://)",
+                                "maxLength": 250
+                            },
+                            "wellKnown": {
+                                "type": "string",
+                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname.",
+                                "pattern": "^(https?://)",
+                                "maxLength": 250
+                            }
+                        }
+                    },
+                    "licenses": {
+                        "type": "array",
+                        "description": "The project's licenses (up to 5). For standard licenses, use the license ID from the SDPX index prefixed by \"spdx:\". eg: \"spdx:GPL-3.0\", \"spdx:CC-BY-SA-4.0\".",
+                        "maxItems": 5,
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "description": "Up to 10 general tags describing the project. For reference, see https://floss.fund/static/project-tags.txt.",
+                        "maxItems": 10,
+                        "items": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]+$",
+                            "maxLength": 32
+                        }
+                    }
+                }
+            }
+        },
+        "funding": {
+            "type": "object",
+            "description": "This describes one or more channels via which the entity can receive funds.",
+            "required": ["channels", "plans"],
+            "properties": {
+                "channels": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["guid", "type"],
+                        "properties": {
+                            "guid": {
+                                "type": "string",
+                                "description": "A short unique ID for the channel. Lowercase-alphanumeric-dashes only. eg: mybank, my-paypal.",
+                                "pattern": "^[a-z0-9-]+$",
+                                "maxLength": 32
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "Type of the channel.",
+                                "enum": ["bank", "payment-provider", "cheque", "cash", "other"]
+                            },
+                            "address": {
+                                "type": "string",
+                                "description": "A short unstructured textual representation of the payment address for the channel. eg: \"Account: 12345 (branch: ABCX)\", \"mypaypal@domain.com\", \"https://payment-url.com\", or a physical address for cheques.",
+                                "maxLength": 250
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Any additional description or instructions for the payment channel.",
+                                "maxLength": 500
+                            }
+                        }
+                    }
+                },
+                "plans": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["guid", "status", "name", "amount", "currency", "frequency", "channels"],
+                        "properties": {
+                            "guid": {
+                                "type": "string",
+                                "description": "A short unique ID for the plan. Lowercase-alphanumeric-dashes only. eg: mybank, paypal.",
+                                "pattern": "^[a-z0-9-]+$",
+                                "maxLength": 32
+                            },
+                            "status": {
+                                "type": "string",
+                                "description": "Indicates whether this plan is currently active or inactive.",
+                                "enum": ["active", "inactive"]
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the funding plan. eg: \"Starter support plan\", \"Infra hosting\", \"Monthly funding plan\".",
+                                "maxLength": 250
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Any additional description or instructions for the funding plan."
+                            },
+                            "amount": {
+                                "type": "number",
+                                "description": "The solicited amount for this plan. 0 is a wildcard that indicates \"any amount\"."
+                            },
+                            "currency": {
+                                "type": "string",
+                                "description": "Three letter ISO 4217 currency code. eg: USD, EUR.",
+                                "pattern": "^[A-Z]{3}$"
+                            },
+                            "frequency": {
+                                "type": "string",
+                                "description": "Frequency of the funding.",
+                                "enum": ["one-time", "weekly", "fortnightly", "monthly", "yearly", "other"]
+                            },
+                            "channels": {
+                                "type": "array",
+                                "description": "One or more channel IDs defined in channels[] via which this plan can accept payments",
+                                "items": {
+                                    "type": "string",
+                                    "pattern": "^[a-z0-9-]+$",
+                                    "maxLength": 32
+                                }
+                            }
+                        }
+                    }
+                },
+                "history": {
+                    "type": "array",
+                    "description": "A simple summary of funding history. Only include if at least one, either income or expenses, have to be communicated.",
+                    "items": {
+                        "type": "object",
+                        "required": ["year", "currency"],
+                        "properties": {
+                            "year": {
+                                "type": "integer",
+                                "description": "Year (fiscal, preferably)."
+                            },
+                            "income": {
+                                "type": "number",
+                                "description": "Income for the year."
+                            },
+                            "expenses": {
+                                "type": "number",
+                                "description": "Expenses for the year."
+                            },
+                            "taxes": {
+                                "type": "number",
+                                "description": "Taxes for the year."
+                            },
+                            "currency": {
+                                "type": "string",
+                                "description": "Three letter ISO 4217 currency code. eg: USD, EUR.",
+                                "pattern": "^[A-Z]{3}$"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Any additional description.",
+                                "maxLength": 500
+                            }
+                        }
+                    }
+                }
+            }
         }
-    },
-
-    // Optional. One or more projects for which the funding is solicited.
-    "projects": [{
-        "guid": "",                     // Required. A short unique ID for the project. Lowercase-alphanumeric-dashes only. eg: my-cool-project. Max len 32.
-        "name": "",                     // Required. Name of the project. Max len 250.
-        "description": "",              // Required. Description of the project. Max len 2000.
-        "webpageUrl": {
-            "url": "",                  // Required. Webpage with information about the project. Starts with https:// or http://. Max len 250.
-            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. Starts with https:// or http://. Max len 250.
-        },
-        "repositoryUrl": {
-            "url": "",                  // Required. URL of the repository where the project's source code and other assets are available. Starts with https:// or http://. Max len 250.
-            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. Starts with https:// or http://. Max len 250.
-        },
-        "licenses": [],                 // Required. The project's licenses (up to 5). For standard licenses, use the license ID from the SDPX index prefixed by "spdx:". eg: "spdx:GPL-3.0", "spdx:CC-BY-SA-4.0"
-        "tags": []                      // Required. Up to 10 general tags describing the project. Lowercase-alphanumeric-dashes (max 32 chars). eg: ["programming", "developer-tools"]. For reference, see tags.txt
-    }],
-
-    // Required.
-    "funding": {
-        // Required. This describes one or more channels via which the entity can receive funds.
-        "channels": [{
-            "guid": "",                 // Required. A short unique ID for the channel. Lowercase-alphanumeric-dashes only. eg: mybank, my-paypal. Max len 32.
-            "type": "",                 // Required. [bank, payment-provider, cheque, cash, other].
-            "address": "",              // Optional. A short unstructured textual representation of the payment address for the channel. eg: "Account: 12345 (branch: ABCX)", "mypaypal@domain.com", "https://payment-url.com", or a physical address for cheques. Max len 250.
-            "description": ""           // Optional. Any additional description or instructions for the payment channel. Max len 500.
-        }],
-
-        // Required. One or more funding and payment plans.
-        "plans": [{
-            "guid": "",                 // Required. A short unique ID for the plan. Lowercase-alphanumeric-dashes only. eg: mybank, paypal. Max len 32.
-            "status": "",               // Required. [active, inactive]. Indicates whether this plan is currently active or inactive.
-            "name": "",                 // Required. Name of the funding plan. eg: "Starter support plan", "Infra hosting", "Monthly funding plan".
-            "description": "",          // Optional. Any additional description or instructions for the funding plan.
-            "amount": 0,                // Required. The solicited amount for this plan. 0 is a wildcard that indicates "any amount".
-            "currency": "",             // Required. Three letter ISO 4217 currency code. eg: USD
-            "frequency": "",            // Required. [one-time, weekly, fortnightly, monthly, yearly, other]
-            "channels": []              // Required. One or more channel IDs defined in channels[] via which this plan can accept payments.
-        }],
-
-        // Optional. A simple summary of funding history. Only include if at least one, either income or expenses, have to be communicated.
-        "history": [{
-            "year": 2024,               // Required. Year (fiscal, preferably).
-            "income": 0,                // Optional.
-            "expenses": 0,              // Optional.
-            "taxes": 0,                 // Optional.
-            "currency": "",             // Required. Three letter ISO 4217 currency code. eg: USD
-            "description": ""           // Optional. Any additional description. Max length 500.
-        }]
     }
 }

--- a/static/static/funding.schema.json
+++ b/static/static/funding.schema.json
@@ -12,7 +12,7 @@
         "description": "",              // Required. Information about the entity. Max len 2000.
         "webpageUrl": {
             "url": "",                  // Required. Webpage with information about the entity. Starts with https:// or http://. Max len 250.
-            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. Starts with https:// or http://. Max len 250.
+            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. Starts with https:// or http:// and ends with /.well-known/funding-manifest-urls. Max len 250.
         }
     },
 
@@ -23,11 +23,11 @@
         "description": "",              // Required. Description of the project. Max len 2000.
         "webpageUrl": {
             "url": "",                  // Required. Webpage with information about the project. Starts with https:// or http://. Max len 250.
-            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. Starts with https:// or http://. Max len 250.
+            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. Starts with https:// or http:// and ends with /.well-known/funding-manifest-urls. Max len 250.
         },
         "repositoryUrl": {
             "url": "",                  // Required. URL of the repository where the project's source code and other assets are available. Starts with https:// or http://. Max len 250.
-            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. Starts with https:// or http://. Max len 250.
+            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. Starts with https:// or http:// and ends with /.well-known/funding-manifest-urls. Max len 250.
         },
         "licenses": [],                 // Required. The project's licenses (up to 5). For standard licenses, use the license ID from the SDPX index prefixed by "spdx:". eg: "spdx:GPL-3.0", "spdx:CC-BY-SA-4.0"
         "tags": []                      // Required. Up to 10 general tags describing the project. Lowercase-alphanumeric-dashes (max 32 chars). eg: ["programming", "developer-tools"]. For reference, see tags.txt
@@ -50,7 +50,7 @@
             "name": "",                 // Required. Name of the funding plan. eg: "Starter support plan", "Infra hosting", "Monthly funding plan".
             "description": "",          // Optional. Any additional description or instructions for the funding plan.
             "amount": 0,                // Required. The solicited amount for this plan. 0 is a wildcard that indicates "any amount".
-            "currency": "",             // Required. Three letter ISO 4217 currency code. eg: USD
+            "currency": "",             // Required. Three letter ISO 4217 currency code. eg: USD, EUR
             "frequency": "",            // Required. [one-time, weekly, fortnightly, monthly, yearly, other]
             "channels": []              // Required. One or more channel IDs defined in channels[] via which this plan can accept payments.
         }],
@@ -61,7 +61,7 @@
             "income": 0,                // Optional.
             "expenses": 0,              // Optional.
             "taxes": 0,                 // Optional.
-            "currency": "",             // Required. Three letter ISO 4217 currency code. eg: USD
+            "currency": "",             // Required. Three letter ISO 4217 currency code. eg: USD, EUR
             "description": ""           // Optional. Any additional description. Max length 500.
         }]
     }

--- a/static/static/funding.schema.json
+++ b/static/static/funding.schema.json
@@ -14,12 +14,12 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "description": "Type of the entity. Use the closest approximation.",
+                    "description": "Type of the entity. [individual, group, organisation, other], Use the closest approximation.",
                     "enum": ["individual", "group", "organisation", "other"]
                 },
                 "role": {
                     "type": "string",
-                    "description": "Role in relation to the project. Use the closest approximation.",
+                    "description": "Role in relation to the project. [owner, steward, maintainer, contributor, other]. Use the closest approximation.",
                     "enum": ["owner", "steward", "maintainer", "contributor", "other"]
                 },
                 "name": {
@@ -170,7 +170,7 @@
                             },
                             "type": {
                                 "type": "string",
-                                "description": "Type of the channel.",
+                                "description": "Type of the channel. [bank, payment-provider, cheque, cash, other].",
                                 "enum": ["bank", "payment-provider", "cheque", "cash", "other"]
                             },
                             "address": {
@@ -200,7 +200,7 @@
                             },
                             "status": {
                                 "type": "string",
-                                "description": "Indicates whether this plan is currently active or inactive.",
+                                "description": "Indicates whether this plan is currently active or inactive. [active, inactive].",
                                 "enum": ["active", "inactive"]
                             },
                             "name": {
@@ -223,7 +223,7 @@
                             },
                             "frequency": {
                                 "type": "string",
-                                "description": "Frequency of the funding.",
+                                "description": "Frequency of the funding. [one-time, weekly, fortnightly, monthly, yearly, other]",
                                 "enum": ["one-time", "weekly", "fortnightly", "monthly", "yearly", "other"]
                             },
                             "channels": {

--- a/static/static/funding.schema.json
+++ b/static/static/funding.schema.json
@@ -1,286 +1,68 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "required": ["version", "entity", "funding"],
-    "properties": {
-        "version": {
-            "type": "string",
-            "description": "Schema version"
-        },
-        "entity": {
-            "type": "object",
-            "description": "The entity associated with the project, soliciting funds.",
-            "required": ["type", "role", "name", "email", "description", "webpageUrl"],
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "description": "Type of the entity. [individual, group, organisation, other], Use the closest approximation.",
-                    "enum": ["individual", "group", "organisation", "other"]
-                },
-                "role": {
-                    "type": "string",
-                    "description": "Role in relation to the project. [owner, steward, maintainer, contributor, other]. Use the closest approximation.",
-                    "enum": ["owner", "steward", "maintainer", "contributor", "other"]
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Name of the entity.",
-                    "maxLength": 250
-                },
-                "email": {
-                    "type": "string",
-                    "description": "Contact email.",
-                    "maxLength": 250
-                },
-                "phone": {
-                    "type": "string",
-                    "description": "Contact phone number. Generally suitable for organisations.",
-                    "maxLength": 32
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Information about the entity.",
-                    "maxLength": 2000
-                },
-                "webpageUrl": {
-                    "type": "object",
-                    "required": ["url"],
-                    "properties": {
-                        "url": {
-                            "type": "string",
-                            "description": "Webpage with information about the entity.",
-                            "anyOf": [
-                                { "pattern": "^(https?://)" },
-                                { "pattern": "^$" }
-                            ],
-                            "maxLength": 250
-                        },
-                        "wellKnown": {
-                            "type": "string",
-                            "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
-                            "anyOf": [
-                                { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
-                                { "pattern": "^$" }
-                            ],
-                            "maxLength": 250
-                        }
-                    }
-                }
-            }
-        },
-        "projects": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "description": "One or more projects for which the funding is solicited.",
-                "required": ["guid", "name", "description", "webpageUrl", "repositoryUrl", "licenses", "tags"],
-                "properties": {
-                    "guid": {
-                        "type": "string",
-                        "description": "A short unique ID for the project. Lowercase-alphanumeric-dashes only. eg: my-cool-project.",
-                        "anyOf": [
-                            { "pattern": "^[a-z0-9-]+$" },
-                            { "pattern": "^$" }
-                        ],
-                        "maxLength": 32
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Name of the project.",
-                        "maxLength": 250
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Description of the project.",
-                        "maxLength": 2000
-                    },
-                    "webpageUrl": {
-                        "type": "object",
-                        "required": ["url"],
-                        "properties": {
-                            "url": {
-                                "type": "string",
-                                "description": "Webpage with information about the project.",
-                                "pattern": "^(https?://)",
-                                "maxLength": 250
-                            },
-                            "wellKnown": {
-                                "type": "string",
-                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
-                                "anyOf": [
-                                    { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
-                                    { "pattern": "^$" }
-                                ],
-                                "maxLength": 250
-                            }
-                        }
-                    },
-                    "repositoryUrl": {
-                        "type": "object",
-                        "required": ["url"],
-                        "properties": {
-                            "url": {
-                                "type": "string",
-                                "description": "URL of the repository where the project's source code and other assets are available.",
-                                "pattern": "^(https?://)",
-                                "maxLength": 250
-                            },
-                            "wellKnown": {
-                                "type": "string",
-                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should be a file in the repository to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
-                                "anyOf": [
-                                    { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
-                                    { "pattern": "^$" }
-                                ],
-                                "maxLength": 250
-                            }
-                        }
-                    },
-                    "licenses": {
-                        "type": "array",
-                        "description": "The project's licenses (up to 5). For standard licenses, use the license ID from the SDPX index prefixed by \"spdx:\". eg: \"spdx:GPL-3.0\", \"spdx:CC-BY-SA-4.0\".",
-                        "maxItems": 5,
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "tags": {
-                        "type": "array",
-                        "description": "Up to 10 general tags describing the project. For reference, see https://floss.fund/static/project-tags.txt.",
-                        "maxItems": 10,
-                        "items": {
-                            "type": "string",
-                            "pattern": "^[a-z0-9-]+$",
-                            "maxLength": 32
-                        }
-                    }
-                }
-            }
-        },
-        "funding": {
-            "type": "object",
-            "description": "This describes one or more channels via which the entity can receive funds.",
-            "required": ["channels", "plans"],
-            "properties": {
-                "channels": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["guid", "type"],
-                        "properties": {
-                            "guid": {
-                                "type": "string",
-                                "description": "A short unique ID for the channel. Lowercase-alphanumeric-dashes only. eg: mybank, my-paypal.",
-                                "pattern": "^[a-z0-9-]+$",
-                                "maxLength": 32
-                            },
-                            "type": {
-                                "type": "string",
-                                "description": "Type of the channel. [bank, payment-provider, cheque, cash, other].",
-                                "enum": ["bank", "payment-provider", "cheque", "cash", "other"]
-                            },
-                            "address": {
-                                "type": "string",
-                                "description": "A short unstructured textual representation of the payment address for the channel. eg: \"Account: 12345 (branch: ABCX)\", \"mypaypal@domain.com\", \"https://payment-url.com\", or a physical address for cheques.",
-                                "maxLength": 250
-                            },
-                            "description": {
-                                "type": "string",
-                                "description": "Any additional description or instructions for the payment channel.",
-                                "maxLength": 500
-                            }
-                        }
-                    }
-                },
-                "plans": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["guid", "status", "name", "amount", "currency", "frequency", "channels"],
-                        "properties": {
-                            "guid": {
-                                "type": "string",
-                                "description": "A short unique ID for the plan. Lowercase-alphanumeric-dashes only. eg: mybank, paypal.",
-                                "pattern": "^[a-z0-9-]+$",
-                                "maxLength": 32
-                            },
-                            "status": {
-                                "type": "string",
-                                "description": "Indicates whether this plan is currently active or inactive. [active, inactive].",
-                                "enum": ["active", "inactive"]
-                            },
-                            "name": {
-                                "type": "string",
-                                "description": "Name of the funding plan. eg: \"Starter support plan\", \"Infra hosting\", \"Monthly funding plan\".",
-                                "maxLength": 250
-                            },
-                            "description": {
-                                "type": "string",
-                                "description": "Any additional description or instructions for the funding plan."
-                            },
-                            "amount": {
-                                "type": "number",
-                                "description": "The solicited amount for this plan. 0 is a wildcard that indicates \"any amount\"."
-                            },
-                            "currency": {
-                                "type": "string",
-                                "description": "Three letter ISO 4217 currency code. eg: USD, EUR.",
-                                "pattern": "^[A-Z]{3}$"
-                            },
-                            "frequency": {
-                                "type": "string",
-                                "description": "Frequency of the funding. [one-time, weekly, fortnightly, monthly, yearly, other]",
-                                "enum": ["one-time", "weekly", "fortnightly", "monthly", "yearly", "other"]
-                            },
-                            "channels": {
-                                "type": "array",
-                                "description": "One or more channel IDs defined in channels[] via which this plan can accept payments",
-                                "items": {
-                                    "type": "string",
-                                    "pattern": "^[a-z0-9-]+$",
-                                    "maxLength": 32
-                                }
-                            }
-                        }
-                    }
-                },
-                "history": {
-                    "type": "array",
-                    "description": "A simple summary of funding history. Only include if at least one, either income or expenses, have to be communicated.",
-                    "items": {
-                        "type": "object",
-                        "required": ["year", "currency"],
-                        "properties": {
-                            "year": {
-                                "type": "integer",
-                                "description": "Year (fiscal, preferably)."
-                            },
-                            "income": {
-                                "type": "number",
-                                "description": "Income for the year."
-                            },
-                            "expenses": {
-                                "type": "number",
-                                "description": "Expenses for the year."
-                            },
-                            "taxes": {
-                                "type": "number",
-                                "description": "Taxes for the year."
-                            },
-                            "currency": {
-                                "type": "string",
-                                "description": "Three letter ISO 4217 currency code. eg: USD, EUR.",
-                                "pattern": "^[A-Z]{3}$"
-                            },
-                            "description": {
-                                "type": "string",
-                                "description": "Any additional description.",
-                                "maxLength": 500
-                            }
-                        }
-                    }
-                }
-            }
+    "version": "v1.0.0",
+
+    // Required. The entity associated with the project, soliciting funds.
+    // This can be an individual, organisation, community etc.
+    "entity": {
+        "type": "",                     // Required. [individual, group, organisation, other]. Use the closest approximation.
+        "role": "",                     // Required. [owner, steward, maintainer, contributor, other]. Use the closest approximation.
+        "name": "",                     // Required. Name of the entity. Max len 250.
+        "email": "",                    // Required. Max len 250.
+        "phone": "",                    // Optional. Generally suitable for organisations. Max len 32.
+        "description": "",              // Required. Information about the entity. Max len 2000.
+        "webpageUrl": {
+            "url": "",                  // Required. Webpage with information about the entity. Starts with https:// or http://. Max len 250.
+            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. Starts with https:// or http://. Max len 250.
         }
+    },
+
+    // Optional. One or more projects for which the funding is solicited.
+    "projects": [{
+        "guid": "",                     // Required. A short unique ID for the project. Lowercase-alphanumeric-dashes only. eg: my-cool-project. Max len 32.
+        "name": "",                     // Required. Name of the project. Max len 250.
+        "description": "",              // Required. Description of the project. Max len 2000.
+        "webpageUrl": {
+            "url": "",                  // Required. Webpage with information about the project. Starts with https:// or http://. Max len 250.
+            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. Starts with https:// or http://. Max len 250.
+        },
+        "repositoryUrl": {
+            "url": "",                  // Required. URL of the repository where the project's source code and other assets are available. Starts with https:// or http://. Max len 250.
+            "wellKnown": ""             // Optional. Required if the above url and the URL of the funding.json manifest do not have the same hostname. Starts with https:// or http://. Max len 250.
+        },
+        "licenses": [],                 // Required. The project's licenses (up to 5). For standard licenses, use the license ID from the SDPX index prefixed by "spdx:". eg: "spdx:GPL-3.0", "spdx:CC-BY-SA-4.0"
+        "tags": []                      // Required. Up to 10 general tags describing the project. Lowercase-alphanumeric-dashes (max 32 chars). eg: ["programming", "developer-tools"]. For reference, see tags.txt
+    }],
+
+    // Required.
+    "funding": {
+        // Required. This describes one or more channels via which the entity can receive funds.
+        "channels": [{
+            "guid": "",                 // Required. A short unique ID for the channel. Lowercase-alphanumeric-dashes only. eg: mybank, my-paypal. Max len 32.
+            "type": "",                 // Required. [bank, payment-provider, cheque, cash, other].
+            "address": "",              // Optional. A short unstructured textual representation of the payment address for the channel. eg: "Account: 12345 (branch: ABCX)", "mypaypal@domain.com", "https://payment-url.com", or a physical address for cheques. Max len 250.
+            "description": ""           // Optional. Any additional description or instructions for the payment channel. Max len 500.
+        }],
+
+        // Required. One or more funding and payment plans.
+        "plans": [{
+            "guid": "",                 // Required. A short unique ID for the plan. Lowercase-alphanumeric-dashes only. eg: mybank, paypal. Max len 32.
+            "status": "",               // Required. [active, inactive]. Indicates whether this plan is currently active or inactive.
+            "name": "",                 // Required. Name of the funding plan. eg: "Starter support plan", "Infra hosting", "Monthly funding plan".
+            "description": "",          // Optional. Any additional description or instructions for the funding plan.
+            "amount": 0,                // Required. The solicited amount for this plan. 0 is a wildcard that indicates "any amount".
+            "currency": "",             // Required. Three letter ISO 4217 currency code. eg: USD
+            "frequency": "",            // Required. [one-time, weekly, fortnightly, monthly, yearly, other]
+            "channels": []              // Required. One or more channel IDs defined in channels[] via which this plan can accept payments.
+        }],
+
+        // Optional. A simple summary of funding history. Only include if at least one, either income or expenses, have to be communicated.
+        "history": [{
+            "year": 2024,               // Required. Year (fiscal, preferably).
+            "income": 0,                // Optional.
+            "expenses": 0,              // Optional.
+            "taxes": 0,                 // Optional.
+            "currency": "",             // Required. Three letter ISO 4217 currency code. eg: USD
+            "description": ""           // Optional. Any additional description. Max length 500.
+        }]
     }
 }

--- a/static/static/funding.schema.json
+++ b/static/static/funding.schema.json
@@ -57,9 +57,9 @@
                         },
                         "wellKnown": {
                             "type": "string",
-                            "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname.",
+                            "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
                             "anyOf": [
-                                { "pattern": "^(https?://)" },
+                                { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
                                 { "pattern": "^$" }
                             ],
                             "maxLength": 250
@@ -106,8 +106,11 @@
                             },
                             "wellKnown": {
                                 "type": "string",
-                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname.",
-                                "pattern": "^(https?://)",
+                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
+                                "anyOf": [
+                                    { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
+                                    { "pattern": "^$" }
+                                ],
                                 "maxLength": 250
                             }
                         }
@@ -124,8 +127,11 @@
                             },
                             "wellKnown": {
                                 "type": "string",
-                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname.",
-                                "pattern": "^(https?://)",
+                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should be a file in the repository to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
+                                "anyOf": [
+                                    { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
+                                    { "pattern": "^$" }
+                                ],
                                 "maxLength": 250
                             }
                         }


### PR DESCRIPTION
This pull requests updates the `funding.schema.json` file to use a `json-schema.org` schema definition. This makes it possible to validate the content of a `funding.json` file inside for example Visual Studio Code:

![image](https://github.com/user-attachments/assets/0a05f2ee-311f-4a45-8975-b628fefba494)

It will also show the description as shown in the image above and do code completion. I have also updated the `funding.example.json` file to include this schema. I am not sure if this should be the url maybe the file should be moved to a `v1.0.0` folder and be changed to `https://floss.fund/static/v1.0.0/funding.schema.json#` or `https://floss.fund/schema/v1.0.0/funding.schema.json#`? I don't mind updating this PR to include those changes but feel free to merge my PR and make the changes yourself.